### PR TITLE
Change Feature click behavior. 

### DIFF
--- a/client/js/mapshup/lib/core/Map/FeatureInfo.js
+++ b/client/js/mapshup/lib/core/Map/FeatureInfo.js
@@ -709,7 +709,7 @@
              * Otherwise it is set on the middle of the clicked object if it is a Point and on the clicked xy
              * if it is a LineString or a Polygon
              */
-            self._p.setMapXY(self._triggered ? M.Map.map.getCenter() : (feature.geometry.CLASS_NAME === "OpenLayers.Geometry.Point" ? feature.geometry.getBounds().getCenterLonLat() : M.Map.map.getLonLatFromPixel(M.Map.mousePosition)));
+            self._p.setMapXY(feature.geometry.getBounds().getCenterLonLat());
 
             /*
              * This is a bit tricky...

--- a/client/js/mapshup/lib/plugins/LayersManager.js
+++ b/client/js/mapshup/lib/plugins/LayersManager.js
@@ -845,10 +845,14 @@
                         e.preventDefault();
                         e.stopPropagation();
 
-                        /*
-                         * Zoom on feature and select it
+                        /**
+                         * Center (if necessary) on feature and select it
                          */
-                        M.Map.zoomTo(f.geometry.getBounds());
+                        var center = f.geometry.getBounds().getCenterLonLat();
+                        if (!M.Map.map.getExtent().containsLonLat(center)) {
+                            M.Map.map.setCenter(center);
+                        }
+
                         M.Map.featureInfo.select(f, true);
                         self.hilite(f);
 


### PR DESCRIPTION
Replace ZoomTo clicked feature with a map center operation if required (e.g. when the feature was not visible on the map). No zoom factor update anymore. The popup is still displayed at the Feature center on the map.