### PR TITLE
[RO] Fix Bug for API plugin with GeoJSON provided in data parameter.

### DIFF
--- a/client/js/mapshup/lib/layerTypes/GeoJSON.js
+++ b/client/js/mapshup/lib/layerTypes/GeoJSON.js
@@ -122,27 +122,41 @@
              * read from data description
              */
             if (layerDescription.hasOwnProperty("data")) {
-                newLayer.destroyFeatures();
-                if (!self.load({
-                    data:layerDescription.data,
-                    layerDescription:layerDescription, 
-                    layer:newLayer,
-                    zoomOnNew:layerDescription.zoomOnNew
-                })) {
-                   /*
-                    * Tell mapshup that layer is loaded
-                    */
-                    newLayer["_M"].isLoaded = true;
 
-                    /*
-                    * Tell mapshup that no features were added
-                    */
-                    Map.events.trigger("layersend", {
-                        action:"features",
-                        layer:newLayer
-                    });
-                    //M.Map.removeLayer(newLayer, false);
-                }
+                /*
+                 * First set the isLoaded status to false to avoid
+                 * annoying popup telling that the layer is added before
+                 * the data has been effectively retrieve from server
+                 */
+                newLayer['_M'].isLoaded = false;
+
+                /**
+                 * Execute the following function in 500ms in order to let OpenLayer properly create the layer
+                 * Otherwise the layer creation is failed
+                 */
+                window.setTimeout( function() {
+
+                    newLayer.destroyFeatures();
+                    if (!self.load({
+                        data:layerDescription.data,
+                        layerDescription:layerDescription,
+                        layer:newLayer,
+                        zoomOnNew:layerDescription.zoomOnNew
+                    })) {
+                       /*
+                        * Tell mapshup that layer is loaded
+                        */
+                        newLayer["_M"].isLoaded = true;
+
+                        /*
+                        * Tell mapshup that no features were added
+                        */
+                        Map.events.trigger("layersend", {
+                            action:"features",
+                            layer:newLayer
+                        });
+                    }
+                }, 500);
             }
             /*
              * Otherwise, read data asynchronously from url


### PR DESCRIPTION
Use the following function to test before and after the patch :

	function trigger_feature_add() {
	 	var json = {"type":"FeatureCollection","properties":{"title":"","id":"a54ff10d-4e79-5fee-abc8-4f87f377e981","totalResults":null,"startIndex":1,"itemsPerPage":1,"query":{"original":{"geo:uid":"743033c9-e661-5ba7-83c2-1851dd451aec"},"analyzed":{"geo:uid":"743033c9-e661-5ba7-83c2-1851dd451aec","searchTerms":[]},"queryAnalyzeProcessingTime":3.09944152832e-6,"searchProcessingTime":0.0162839889526,"hasLocation":false},"links":[{"rel":"self","type":"application\/json","title":"self","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?identifier=743033c9-e661-5ba7-83c2-1851dd451aec"},{"rel":"search","type":"application\/opensearchdescription+xml","title":"_osddLink","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/describe.xml"}]},"features":[{"type":"Feature","id":"743033c9-e661-5ba7-83c2-1851dd451aec","geometry":{"type":"Polygon","coordinates":[[[-72.4332906965,18.6942102007],[-72.1734522725,18.7223374216],[-72.1769651548,18.5272775645],[-72.4289698278,18.4986815033],[-72.4332906965,18.6942102007]]]},"properties":{"collection":"RO","productIdentifier":"PHR1A_PAN_SENSOR_20120313_151810","title":"PLEIADES 1A PAN L1A 2012-03-13 15:18:10","description":"L1A PAN image acquired by PLEIADES 1A on 2012-03-13 at 15:18:10","organisationName":"CNES","startDate":"2012-03-13T15:18:10Z","completionDate":"2012-03-13T15:18:10Z","productType":null,"processingLevel":"L1A","platform":"PLEIADES 1A","instrument":"PHR1A","resolution":0.96,"orbitNumber":0,"quicklook":"http:\/\/localhost\/products_summary\/20120313\/ql_PHR1A_PAN_SENSOR_20120313_151810.jpg","thumbnail":"http:\/\/localhost\/products_summary\/20120313\/thumb_PHR1A_PAN_SENSOR_20120313_151810.jpg","updated":"2015-03-10T09:48:04Z","published":"2015-03-10T09:48:04Z","snowCover":0,"cloudCover":0,"keywords":[{"name":"region:_all","id":"region:_all","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?lang=fr&q=","hash":"729ac5531bb5fa6","parentHash":"7ea2037b2dd6940"},{"name":"Ouest","id":"state:ouest","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?lang=fr&q=Ouest","hash":"bb77179abf15323","parentHash":"729ac5531bb5fa6","value":71.64},{"name":"Ha\u00efti","id":"country:haiti","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?lang=fr&q=Ha%C3%AFti","hash":"7ea2037b2dd6940","parentHash":"edff315ea0b7a86","value":89.3},{"name":"Eau","id":"landuse:water","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?lang=fr&q=Eau","hash":"30ab8d81fb40d6c","value":26.15},{"name":"Zone Cultiv\u00e9e","id":"landuse:cultivated","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?lang=fr&q=%22Zone+Cultiv%C3%A9e%22","hash":"a306c45408e6b6f","value":41.24},{"name":"Herbac\u00e9","id":"landuse:herbaceous","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?lang=fr&q=Herbac%C3%A9","hash":"870b2149f9a08a2","value":25.35},{"name":"Am\u00e9rique Du Nord","id":"continent:north america","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?lang=fr&q=%22Am%C3%A9rique+Du+Nord%22","hash":"edff315ea0b7a86"},{"name":"2012","id":"year:2012","hash":"fbe78d7b50fe043","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?q=2012&lang=fr"},{"name":"2012-03","id":"month:2012-03","hash":"33b56216358eee2","parentId":"year:2012","parentHash":"fbe78d7b50fe043","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?q=2012-03&lang=fr"},{"name":"2012-03-13","id":"day:2012-03-13","hash":"8a01502a15e7d68","parentId":"month:2012-03","parentHash":"33b56216358eee2","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?q=2012-03-13&lang=fr"},{"name":"\"PLEIADES 1A\"","id":"platform:\"PLEIADES 1A\"","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?q=%22PLEIADES+1A%22"},{"name":"PHR1A","id":"instrument:PHR1A","href":"http:\/\/localhost\/resto2\/api\/collections\/RO\/search.json?q=PHR1A"}],"hashes":["edff315ea0b7a86","\"continent:north america\"","7ea2037b2dd6940","country:haiti","729ac5531bb5fa6","region:_all","bb77179abf15323","state:ouest","a306c45408e6b6f","landuse:cultivated","30ab8d81fb40d6c","landuse:water","870b2149f9a08a2","landuse:herbaceous","6b8a2e8a5d4bbc9","880c5b28566ece8","834025678ae0f93","4c5c1ebeecb9fd5","2b0a27122d1e850","7940332dc527508","73758976389b2b2","instrument:PHR1A","96531f97967ec0e","\"platform:PLEIADES 1A\"","ef2c84a88adcdb4","processingLevel:L1A","year:2012","month:03","day:13"],"incidenceAngle":32.8734122217,"productMode":"PAN","productCrs":null,"productGeometry":null,"landUse":{"waterCover":26.15,"herbaceousCover":25.35,"cultivatedCover":41.24},"services":{"download":{"url":"http:\/\/localhost\/resto2\/collections\/RO\/743033c9-e661-5ba7-83c2-1851dd451aec\/download","mimeType":"application\/unknown","size":569421297,"checksum":"d41d8cd98f00b204e9800998ecf8427e"}},"links":[{"rel":"alternate","type":"text\/html","title":"Lien HTML pour 743033c9-e661-5ba7-83c2-1851dd451aec","href":"http:\/\/localhost\/resto2\/collections\/RO\/743033c9-e661-5ba7-83c2-1851dd451aec.html?lang=fr"},{"rel":"alternate","type":"application\/json","title":"Lien GeoJSON pour 743033c9-e661-5ba7-83c2-1851dd451aec","href":"http:\/\/localhost\/resto2\/collections\/RO\/743033c9-e661-5ba7-83c2-1851dd451aec.json?lang=fr"},{"rel":"alternate","type":"application\/atom+xml","title":"Lien ATOM pour 743033c9-e661-5ba7-83c2-1851dd451aec","href":"http:\/\/localhost\/resto2\/collections\/RO\/743033c9-e661-5ba7-83c2-1851dd451aec.atom?lang=fr"}]}}]};

		var message = {
			command: "addLayer",
			options: {
				data : json,
				content_type: "application/json",
				type: "GeoJSON"
			}
		};

		var messageString = encodeURIComponent(JSON.stringify(message));
		window.postMessage(messageString, "*");
	}

Before the patch, the `features` event was triggered before the `add` one. OpenLayer is broken after this test, the layer can't be removed... 

After the patch, the layer is properly created by OpenLayer and then the features are added. OpenLayer is no more broken.  